### PR TITLE
PR for: GIT-1 (push-proxy should use key/certificate files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ For organizations who want to keep internal communications behind their firewall
   2. Download Mattermost Notification Server v0.1.1 with `wget https://github.com/mattermost/push-proxy/releases/download/v0.1.1/matter-push-proxy.tar.gz`.
   3. Uncompress the file with `tar -xvzf matter-push-proxy.tar.gz`.
 2. Update `config.json` with your private and public keys.
-  3. Edit using `vi /home/ubuntu/push-proxy/config/config.json` and set `ApplePushCertPublic` and `ApplePushCertPrivate` based on the public and private keys previously generated. 
+  1. Edit using `vi /home/ubuntu/push-proxy/config/config.json` and set `ApplePushCertPublic` and `ApplePushCertPrivate`, this should be a path to the public and private keys previously generated. 
 3. Verify push notifications are working by mentioning a user who is offline, which should trigger a push notification.

--- a/server/server.go
+++ b/server/server.go
@@ -89,7 +89,7 @@ func sendAppleNotification(msg *PushNotification) {
 	pn := apns.NewPushNotification()
 	pn.DeviceToken = msg.DeviceId
 	pn.AddPayload(payload)
-	client := apns.BareClient(CfgPP.ApplePushServer, CfgPP.ApplePushCertPublic, CfgPP.ApplePushCertPrivate)
+	client := apns.NewClient(CfgPP.ApplePushServer, CfgPP.ApplePushCertPublic, CfgPP.ApplePushCertPrivate)
 	resp := client.Send(pn)
 
 	if resp.Error != nil {


### PR DESCRIPTION
This pull request implements the changes required for https://github.com/mattermost/push-proxy/issues/1

Instead of inserting the key and certificate directly into the `config.json` file, you should now define a path to the files on disk.

You can verify that the server operates normally by using `curl`:

~~~~
curl http://127.0.0.1:8066/api/v1/send_push -X POST -H "Content-Type: application/json" -d '{
"message":"test",
"badge": 1,
"platform":"apple",
"server_id":"MATTERMOST_DIAG_ID",
"device_id":"IPHONE_DEVICE_ID"
}'
~~~~

Replace `MATTERMOST_DIAG_ID` and `IPHONE_DEVICE_ID` with the relevant values.